### PR TITLE
Return "empty array" rather than "null" if data is missing

### DIFF
--- a/curvedLines.js
+++ b/curvedLines.js
@@ -290,7 +290,7 @@
 				for (var i = 1; i < n - 1; ++i) {
 					var d = (xdata[i + 1] - xdata[i - 1]);
 					if (d == 0) {
-						return null;
+						return [];
 					}
 
 					var s = (xdata[i] - xdata[i - 1]) / d;
@@ -334,7 +334,7 @@
 					var h = (xdata[max] - xdata[min]);
 
 					if (h == 0) {
-						return null;
+						return [];
 					}
 
 					var a = (xdata[max] - xnew[j]) / h;


### PR DESCRIPTION
Been seeing my graphs crash recently, eventually tracked it down to the curved lines plugin setting datapoints.points to null if it didn't have enough input data to generate a curve. This patch makes it return an empty array instead, so the rest of the graph will render correctly and this line will not be plotted, which seems like the most correct thing to do in the situation.
